### PR TITLE
Contextual component tests and basic impl

### DIFF
--- a/packages/ember-htmlbars/lib/keywords/component.js
+++ b/packages/ember-htmlbars/lib/keywords/component.js
@@ -5,6 +5,7 @@
 */
 import Ember from 'ember-metal/core';
 import { keyword } from 'htmlbars-runtime/hooks';
+import closureComponent from 'ember-htmlbars/keywords/closure-component';
 
 /**
   The `{{component}}` helper lets you add instances of `Ember.Component` to a
@@ -59,8 +60,7 @@ export default function(morph, env, scope, params, hash, template, inverse, visi
       keyword('@element_component', morph, env, scope, params, hash, template, inverse, visitor);
       return true;
     }
-
-    return true; // Until we have implemented the contextual component
+    return closureComponent(params, hash);
   } else {
     keyword('@element_component', morph, env, scope, params, hash, template, inverse, visitor);
     return true;

--- a/packages/ember-htmlbars/tests/helpers/closure_component_test.js
+++ b/packages/ember-htmlbars/tests/helpers/closure_component_test.js
@@ -1,0 +1,135 @@
+import Registry from 'container/registry';
+import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
+import ComponentLookup from 'ember-views/component_lookup';
+import Component from 'ember-views/components/component';
+import compile from 'ember-template-compiler/system/compile';
+import run from 'ember-metal/run_loop';
+
+let component, registry, container;
+
+if (Ember.FEATURES.isEnabled('ember-contextual-components')) {
+
+QUnit.module('ember-htmlbars: closure component helper', {
+  setup() {
+    registry = new Registry();
+    container = registry.container();
+
+    registry.optionsForType('template', { instantiate: false });
+    registry.register('component-lookup:main', ComponentLookup);
+  },
+
+  teardown() {
+    runDestroy(component);
+    runDestroy(container);
+    registry = container = component = null;
+  }
+});
+
+QUnit.test('renders with component helper', function() {
+  let expectedText = 'Hodi';
+  registry.register(
+    'template:components/-looked-up',
+    compile(expectedText)
+  );
+
+  let template = compile('{{component (component "-looked-up")}}');
+  component = Component.extend({ container, template }).create();
+
+  runAppend(component);
+  equal(component.$().text(), expectedText, '-looked-up component rendered');
+});
+
+QUnit.test('renders with component helper with invocation params, hash', function() {
+  let LookedUp = Component.extend();
+  LookedUp.reopenClass({
+    positionalParams: ['name']
+  });
+  registry.register(
+    'component:-looked-up',
+    LookedUp
+  );
+  registry.register(
+    'template:components/-looked-up',
+    compile(`{{greeting}} {{name}}`)
+  );
+
+  let template = compile(
+    `{{component (component "-looked-up") "Hodari" greeting="Hodi"}}`
+  );
+  component = Component.extend({ container, template }).create();
+
+  runAppend(component);
+  equal(component.$().text(), "Hodi Hodari", '-looked-up component rendered');
+});
+
+QUnit.test('renders with component helper with curried params, hash', function() {
+  let LookedUp = Component.extend();
+  LookedUp.reopenClass({
+    positionalParams: ['name']
+  });
+  registry.register(
+    'component:-looked-up',
+    LookedUp
+  );
+  registry.register(
+    'template:components/-looked-up',
+    compile(`{{greeting}} {{name}}`)
+  );
+
+  let template = compile(
+    `{{component (component "-looked-up" "Hodari" greeting="Hodi") greeting="Hola"}}`
+  );
+  component = Component.extend({ container, template }).create();
+
+  runAppend(component);
+  equal(component.$().text(), "Hola Hodari", '-looked-up component rendered');
+});
+
+QUnit.test('updates when component path is bound', function() {
+  registry.register(
+    'template:components/-mandarin',
+    compile(`ni hao`)
+  );
+  registry.register(
+    'template:components/-hindi',
+    compile(`Namaste`)
+  );
+
+  let template = compile('{{component (component lookupComponent)}}');
+  component = Component.extend({ container, template }).create();
+
+  runAppend(component);
+  equal(component.$().text(), ``, 'undefined lookupComponent does not render');
+  run(() => {
+    component.set('lookupComponent', '-mandarin');
+  });
+  equal(component.$().text(), `ni hao`,
+        'mandarin lookupComponent renders greeting');
+  run(() => {
+    component.set('lookupComponent', '-hindi');
+  });
+  equal(component.$().text(), `Namaste`,
+        'hindi lookupComponent renders greeting');
+});
+
+QUnit.test('updates when curried hash argument is bound', function() {
+  registry.register(
+    'template:components/-looked-up',
+    compile(`{{greeting}}`)
+  );
+
+  let template = compile(
+    `{{component (component "-looked-up" greeting=greeting)}}`
+  );
+  component = Component.extend({ container, template }).create();
+
+  runAppend(component);
+  equal(component.$().text(), "", '-looked-up component rendered');
+  run(() => {
+    component.set('greeting', 'Hodi');
+  });
+  equal(component.$().text(), `Hodi`,
+        'greeting is bound');
+});
+
+}


### PR DESCRIPTION
@Serabe this adds an initial tested implementation for things like:

``` hbs
{{component (component 'foo' baz=bar) baz=betterBar}}
```

refs https://github.com/emberjs/ember.js/pull/12285.
